### PR TITLE
feat(core): add option to flag appsettings as Converted to allow moving away from the typed shizzle

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -1172,6 +1172,7 @@
     "DataType": "bool",
     "Tickets": ["OPTR-25482"],
     "Default": "false",
-    "Options": []
+    "Options": [],
+    "Converted": true
   }
 ]

--- a/appsettings.schema.json
+++ b/appsettings.schema.json
@@ -31,6 +31,11 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "Converted": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "Are the apps ready for the string-only version? This should be true for all new settings."
                 }
             },
             "required": [


### PR DESCRIPTION
See https://github.com/new-black/eva/pull/7006