### PR TITLE
Add pack slip scan requirement setting

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -1772,6 +1772,15 @@
     "Converted": true
   },
   {
+    "Name": "App:ReceiveGoods:PackSlipScanRequirement",
+    "Description": "Determines the pack slip scanning requirement for Receive Goods tasks: require validation before opening the task, require validation before proceeding within the task, or make scanning optional",
+    "DataType": "string",
+    "Tickets": ["OPTR-45274"],
+    "Default": "RequireBeforeOpening",
+    "Options": ["RequireBeforeOpening", "RequireBeforeProceed", "Never"],
+    "Converted": true
+  },
+  {
     "Name": "App:LoyaltyWarningIndications",
     "Description": "This settings decideds on which warning indications we show in the consumer profile, { PreferredSubscriptions = 1, OpenSurveys = 2, MissingUserData = 4, OpenCases = 8, CouponExpiry = 16, ALL = 31}",
     "DataType": "int",


### PR DESCRIPTION
Added configuration for pack slip scanning requirement in Receive Goods tasks.

https://n6k.atlassian.net/browse/OPTR-45274