### PR TITLE
Add App:DisplayKnowledgeCenter

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -1870,6 +1870,15 @@
     "Converted": true
   },
   {
+    "Name": "App:DisplayKnowledgeCenter",
+    "Description": "Determines whether the knowledge center is displayed in the app.",
+    "DataType": "bool",
+    "Tickets": [],
+    "Default": "false",
+    "Options": [],
+    "Converted": true
+  },
+  {
     "Name": "App:FullOnboardingOnCFD",
     "Description": "Determines if full headless onboarding is allowed on the CFD",
     "DataType": "bool",


### PR DESCRIPTION
This pull request adds a new configuration option to the application settings. The main change introduces a toggle for displaying the knowledge center in the app.

New configuration option:

* Added the `App:DisplayKnowledgeCenter` setting to `appsettings.json`, allowing control over whether the knowledge center is shown in the application. The default value is set to `false`.