### PR TITLE
Add App:Control:AdjustStockOnPeriodClosing

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -1913,5 +1913,14 @@
     "Default": "false",
     "Options": [],
     "Converted": true
+  },
+  {
+    "Name": "App:Control:AdjustStockOnPeriodClosing",
+    "Description": "When enabled, store employees can resolve negative-stock impediments directly from the period closing screen in the Control app, without navigating away to adjust stock manually.",
+    "DataType": "bool",
+    "Tickets": ["OPTR-47388"],
+    "Default": "false",
+    "Options": [],
+    "Converted": true
   }
 ]


### PR DESCRIPTION
This pull request adds a new configuration option to the application's settings. The new option allows store employees to resolve negative stock issues directly from the period closing screen in the Control app, streamlining the workflow.

**New Feature:**

* Added `App:Control:AdjustStockOnPeriodClosing` setting to `appsettings.json`, enabling negative-stock resolution from the period closing screen in the Control app.

Related AppSuite work: https://github.com/new-black/eva-app-suite/pull/4005