### PR TITLE
chore: validate every json file and check appsettings defaults

### DIFF
--- a/.github/workflows/jsoncheck.yml
+++ b/.github/workflows/jsoncheck.yml
@@ -7,10 +7,12 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Superseded pull request runs are cancelled, but every commit on main keeps its
-  # own completed run — this repository's contents reach all environments, so the
-  # history of what was verified matters more than the saved minutes.
+  # Pull requests share a group per branch so a new commit supersedes the run before
+  # it. Pushes are keyed by commit instead: a shared group would leave the second of
+  # three quick merges pending, and GitHub cancels a pending run when a newer one
+  # queues behind the same group. This repository's contents reach all environments,
+  # so every commit on main keeps its own completed run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/jsoncheck.yml
+++ b/.github/workflows/jsoncheck.yml
@@ -2,9 +2,16 @@ name: JSON check
 
 on:
   push:
-    paths:
-      - "**.json"
+    branches:
+      - main
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Superseded pull request runs are cancelled, but every commit on main keeps its
+  # own completed run — this repository's contents reach all environments, so the
+  # history of what was verified matters more than the saved minutes.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/__tests__/appsettings.test.ts
+++ b/__tests__/appsettings.test.ts
@@ -7,8 +7,9 @@ interface AppSetting {
   Description: string;
   DataType: string;
   Tickets: string[];
-  Default: string;
+  Default: string | null;
   Options: any[];
+  Converted?: boolean;
 }
 
 describe("appsettings.json validation", () => {
@@ -16,6 +17,99 @@ describe("appsettings.json validation", () => {
   const appSettings = JSON.parse(
     fs.readFileSync(appSettingsPath, "utf8")
   ) as AppSetting[];
+
+  const INTEGER_PATTERN = /^-?\d+$/;
+  const DECIMAL_PATTERN = /^-?\d+(\.\d+)?$/;
+  const GUID_PATTERN =
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+  // These rules are deliberately stricter than EVA's runtime, which is lenient
+  // (bool accepts "True" and "1", int.TryParse tolerates surrounding spaces) and
+  // only converts at all when an entry is not marked Converted. Most entries here
+  // are Converted and reach clients as raw strings, so one canonical spelling per
+  // type is the only form every consumer can be relied on to read.
+
+  // Where conversion does run, int and int[] go through int.TryParse: a value
+  // outside this range becomes null and the setting silently never reaches the client.
+  function isWithinInt32Range(value: string): boolean {
+    const parsed = Number(value);
+    return parsed >= -2147483648 && parsed <= 2147483647;
+  }
+
+  // Returns a reason when the default cannot be read as its declared type, or null when it can.
+  // null and "" both mean "no default" and are valid for every type.
+  function describeInvalidDefault(
+    dataType: string,
+    value: string | null
+  ): string | null {
+    if (value === null || value === "") return null;
+
+    switch (dataType) {
+      case "bool":
+        return value === "true" || value === "false"
+          ? null
+          : "expected true or false";
+      case "int":
+        if (!INTEGER_PATTERN.test(value)) return "expected an integer";
+        return isWithinInt32Range(value) ? null : "expected a 32-bit integer";
+      case "decimal":
+        return DECIMAL_PATTERN.test(value) ? null : "expected a decimal";
+      case "guid":
+        return GUID_PATTERN.test(value) ? null : "expected a guid";
+      case "int[]": {
+        const invalidPart = value
+          .split(",")
+          .find((part) => !INTEGER_PATTERN.test(part) || !isWithinInt32Range(part));
+
+        return invalidPart === undefined
+          ? null
+          : `expected comma-separated integers, got ${JSON.stringify(invalidPart)}`;
+      }
+      case "object":
+        try {
+          const parsed = JSON.parse(value);
+          return parsed !== null &&
+            typeof parsed === "object" &&
+            !Array.isArray(parsed)
+            ? null
+            : "expected a json object";
+        } catch {
+          return "expected a json object";
+        }
+      default:
+        // string, string[] and "" carry free-form defaults
+        return null;
+    }
+  }
+
+  it("should have a Default that can be read as its DataType", () => {
+    expect(appSettings.length).toBeGreaterThan(200);
+
+    const invalid = appSettings
+      .map((setting) => ({
+        setting,
+        reason: describeInvalidDefault(setting.DataType, setting.Default),
+      }))
+      .filter(({ reason }) => reason !== null)
+      .map(
+        ({ setting, reason }) =>
+          `${setting.Name} (DataType=${setting.DataType}, Default=${JSON.stringify(setting.Default)}): ${reason}`
+      );
+
+    expect(invalid).toEqual([]);
+  });
+
+  const TICKET_PATTERN = /^[A-Z][A-Z0-9]+-\d+$/;
+
+  it("should reference tickets by key rather than by url", () => {
+    const invalid = appSettings.flatMap((setting) =>
+      setting.Tickets.filter((ticket) => !TICKET_PATTERN.test(ticket)).map(
+        (ticket) => `${setting.Name}: ${JSON.stringify(ticket)}`
+      )
+    );
+
+    expect(invalid).toEqual([]);
+  });
 
   it("should not have duplicate Name entries", () => {
     const nameSet = new Set<string>();

--- a/__tests__/json-syntax.test.ts
+++ b/__tests__/json-syntax.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+describe("json syntax", () => {
+  const root = process.cwd();
+  const files = execFileSync("git", ["ls-files", "-z", "*.json"], {
+    cwd: root,
+    encoding: "utf8",
+  })
+    .split("\0")
+    .filter(Boolean);
+
+  // Guards against the discovery itself silently breaking and the suite passing vacuously.
+  it("should discover the json files in the repository", () => {
+    expect(files).toContain("appsettings.json");
+    expect(files).toContain("app_rules.json");
+    expect(files).toContain("translation/en-US.json");
+  });
+
+  it.each(files)("%s should be parseable", (file) => {
+    const raw = fs.readFileSync(path.join(root, file), "utf8");
+    expect(() => JSON.parse(raw)).not.toThrow();
+  });
+});

--- a/appsettings.json
+++ b/appsettings.json
@@ -318,7 +318,7 @@
     "Name": "App:Order:ShowEstimatedDeliveryTime",
     "Description": "Determines whether we render the delivery proposition card non the checkout or not",
     "DataType": "bool",
-    "Tickets": ["OPTR-5542", " OPTR-4802"],
+    "Tickets": ["OPTR-5542", "OPTR-4802"],
     "Default": "false",
     "Options": []
   },
@@ -861,7 +861,7 @@
     "Name": "App:Pos:DefaultRoute",
     "Description": "Changes what page the POS navigates to after logging in",
     "DataType": "string",
-    "Tickets": ["https://n6k.atlassian.net/browse/OPTR-20309"],
+    "Tickets": ["OPTR-20309"],
     "Default": "sales",
     "Options": [
       "sales",
@@ -1168,7 +1168,7 @@
     "Name": "App:Login:PreferredMethod",
     "Description": "Dictates what tab to be opened on login",
     "DataType": "string",
-    "Tickets": ["https://n6k.atlassian.net/browse/OPTR-22804"],
+    "Tickets": ["OPTR-22804"],
     "Default": "Email",
     "Options": ["Email", "QRCode", "SSO", "PIN"]
   },


### PR DESCRIPTION
Closes gaps in what CI actually checks. Nothing here changes behaviour in any environment.

## Why

`npm run validate` covers `appsettings.json`, `countries.json` and `tipkit/tipkit.json` against their schemas, and the vitest suite checked duplicate names and tipkit ids. That left two holes:

1. **Five files were validated by nothing at all** — `admin_modules_new.json`, `app_rules.json`, `functionalities.json` and the three `translation/*.json`. They have no schema and nothing parsed them, so a syntax error passed CI green. The workflow triggering on `**.json` made them look covered. These files *are* fetched at runtime (`SyncAppRulesTask`, `AdminTemplatesStartupComponent`, `FunctionalityCategoryDownloader`), so a break there reaches every environment.
2. **`Default` was never checked against `DataType`.** The schema types `Default` as `null | string` for every entry regardless of type, so `{"DataType": "int", "Default": "abc"}` is schema-valid. Confirmed: ajv prints `appsettings.json valid` for exactly that. JSON Schema structurally cannot express the rule — only a test can.

That matters because the conversion in `EVA.Core/Configuration/AppSettings/AppSettingsManager.cs:81-101` fails **silently**: `TryConvertToInt` returns null, `FilterNull()` drops unparseable array elements, and `TryParseObject` swallows the exception and ships `null`. A bad default doesn't error anywhere — the setting just quietly disappears for clients.

## What changed

| Commit | |
|---|---|
| `test: parse-check every json file` | New `__tests__/json-syntax.test.ts`. Enumerates tracked files via `git ls-files` and asserts each parses. Includes a guard against the discovery silently returning nothing, because vitest emits zero tests for `it.each([])` rather than failing. |
| `fix: reference tickets by key instead of by jira url` | **The only data change** — see below. |
| `test: check appsettings defaults and ticket references` | `Default` must be readable as its `DataType`; `Tickets` must be ticket keys. |
| `chore: check every pull request commit once and every main commit` | Workflow triggers. |

### The data change, called out deliberately

Three `Tickets` values in `appsettings.json`, nothing else:

- `App:Order:ShowEstimatedDeliveryTime` — `" OPTR-4802"` → `"OPTR-4802"` (leading space)
- `App:Pos:DefaultRoute` — `"https://n6k.atlassian.net/browse/OPTR-20309"` → `"OPTR-20309"`
- `App:Login:PreferredMethod` — `"https://n6k.atlassian.net/browse/OPTR-22804"` → `"OPTR-22804"`

Verified as inert rather than assumed: 226 entries before and after, `Name` order identical, per-entry key order identical, and everything except those three `Tickets` arrays byte-identical. EVA never deserializes the field — `AppSettingAutocompleteInfo` (`AppSettingsManager.cs:22-30`) has no `Tickets` member and the fetch ignores unknown members. It is documentation metadata.

### Workflow

`push` narrowed to `main`, since branch pushes are already covered by `pull_request` — today every PR commit runs the job **twice** (e.g. runs `31144250716` and `31144252661`, same SHA, both green). Added a concurrency group so superseded PR runs cancel.

`cancel-in-progress` is scoped to pull requests only, and push runs are keyed by `github.sha` rather than by ref. Both parts are needed: with a shared group, the second of three quick merges sits pending and GitHub cancels a pending run when a newer one queues behind the same group, so that commit would end up with no completed run at all. Given this repo reaches all environments, knowing which commit was verified is worth more than the saved minutes.

**Trade-off worth knowing:** a push to a branch with no open PR is no longer checked. Feedback arrives when the PR is opened, and nothing can merge unverified.

## Two things stated honestly

- **The `Default` rules are deliberately stricter than the runtime**, not a mirror of it. The runtime accepts `"True"` and `"1"` for bool and tolerates spaces in `int[]`, and only converts at all when an entry is not marked `Converted` — most entries are, and reach clients as raw strings. One canonical spelling per type is the only form every consumer can be relied on to read. The code comment says this too, so nobody goes hunting for a backend rule that doesn't exist.
- **The `Tickets` rule is a lint over documentation quality, not a safety check.** No environment reads the field. Its value is that a future PR pasting a browse URL fails at review time rather than never being noticed.

## Deliberately not done

- **`App:SmartSuggestions:IncludePendingPoints` is a bool declared as `DataType: "string"`** (`Default: "false"`, description reads "Dictates *if* …"). Changing a `DataType` alters what clients receive, so it doesn't belong in a CI PR. No test can catch a mis-declared type — that's the honest ceiling of this check.
- **Schemas for the four unvalidated files.** Getting them from "not parsed" to "must be valid JSON" is the cheap win; authoring schemas needs the owning teams' input.
- **Duplicate keys within a single object.** `JSON.parse` keeps the last silently. Needs a dependency or a hand-rolled scanner; zero instances across all 14 files today.

## Testing

`npm ci && npm run validate && npm test` — all three schemas valid, 20 tests passing.

Every new assertion was proven to fail against crafted bad data, not just observed passing: a corrupted `app_rules.json`, an `int` default of `"abc"` and of `"99999999999999999999"`, an `object` default of `"{not json"` and `"[1,2]"`, an `int[]` of `"1,ean13,3"`, a reintroduced Jira URL, and an empty settings array against the vacuity guard. Each produced exactly one clear failure naming the offender.

---

Written by Fuzzy™ (AI) working with AJ. Note this repo has no `ai-built` label, so it isn't tagged — say the word if you'd like the label created here.

