### PR TITLE
feat(optr-47170): add App:Checkout:AllowStores setting

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -1922,5 +1922,14 @@
     "Default": "false",
     "Options": [],
     "Converted": true
+  },
+  {
+    "Name": "App:Checkout:AllowStores",
+    "Description": "When disabled, order create/edit in Admin Suite Checkout is only allowed in a webshop OU context and store OUs are not selectable. When enabled, order create/edit is also allowed in a store (shop) OU context.",
+    "DataType": "bool",
+    "Tickets": ["OPTR-47170"],
+    "Default": "false",
+    "Options": [],
+    "Converted": true
   }
 ]


### PR DESCRIPTION
## Summary
- Adds the `App:Checkout:AllowStores` setting (OPTR-47170), controlling whether Admin Suite Checkout order create/edit is allowed in a store (shop) OU context in addition to webshop OU context.
- Defaults to `false`, preserving current behavior (webshop-only).

## Test plan
- [ ] Setting appears with correct name/description/default in appsettings.json
- [ ] Downstream consumers reference `App:Checkout:AllowStores` per ticket comments

Ticket: https://n6k.atlassian.net/browse/OPTR-47170

🤖 Generated with [Claude Code](https://claude.com/claude-code)